### PR TITLE
Catbot index unit test wip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ dist
 
 # uploads folder
 uploads/
+
+**/test-notes.js

--- a/package.json
+++ b/package.json
@@ -31,5 +31,16 @@
     "aws-sdk": "^2.1148.0",
     "axios": "^0.27.2",
     "oauth-1.0a": "^2.2.6"
+  },
+  "jest": {
+    "roots": [
+      "<rootDir>"
+    ],
+    "modulePaths": [
+      "<rootDir>/src/services"
+    ],
+    "moduleDirectories": [
+      "node_modules"
+    ]
   }
 }

--- a/src/index-lambda-cat-bot.js
+++ b/src/index-lambda-cat-bot.js
@@ -69,4 +69,5 @@ const handler = async (event) => {
 
 module.exports = {
   handler,
+  isTweetingEnabled,
 };

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,5 +1,13 @@
 const { handler } = require('../../src/index-lambda-cat-bot');
 const s3 = require('../../src/services/s3');
+const twitter = require('../../src/services/twitter');
+
+jest.mock('s3');
+jest.mock('twitter')
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
 
 test('this is a placeholder test', () => {
   console.log('hello, i am running this test!!');
@@ -19,17 +27,21 @@ describe('Empty staging folder reaction', () => {
     // const spy = await jest.spyOn(s3, 'listObjects');
     // spy.mockReturnValue([]);
 
-    s3.listObjects = await jest.fn().mockReturnValue([])
+    s3.listObjects = await jest.fn().mockResolvedValue([])
+    // s3.listObjects.mockResolvedValue([])
 
     // test
     // call handler
-    const test = async() => await handler()
+    // const test = async() => await handler()
 
     // assert 
     // expect a error message will be returned
     // error msg: `Successfully repopulated ${STAGING_FOLDER} folder with ${TWEETED_FOLDER} contents. Proceed to rerun Lambda.`
-    expect(test).toThrow();
+    await expect(handler()).rejects.toThrow('Successfully repopulated');
 
     // spy.mockRestore();
   })
 })
+
+// TOTEST:
+// 

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -48,9 +48,11 @@ describe('Main tweeting function', () => {
     const test = await handler();
 
     // assert
-    expect.assertions(2)
+    expect.assertions(4)
     expect(twitter.uploadImage).toHaveBeenCalled();
+    expect(twitter.uploadImage).toHaveBeenCalledWith(expect.stringContaining(''));
     expect(twitter.createTweet).toHaveBeenCalled();
+    expect(twitter.createTweet).toHaveBeenCalledWith(expect.objectContaining({media_id: 1533168952922108000}));
   })
 })
 
@@ -66,7 +68,7 @@ describe('Error catch of tweeting function', () => {
     s3.listObjects = await jest.fn().mockResolvedValue(fakeImages);
     twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse)
     console.error = jest.fn()
-    
+
     // test and assert
     expect.assertions(2);
     await expect(handler()).rejects.toThrow()

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,9 +1,9 @@
-const { handler} = require('../../src/index-lambda-cat-bot');
+const { handler } = require('../../src/index-lambda-cat-bot');
 const index = require('../../src/index-lambda-cat-bot');
 const s3 = require('../../src/services/s3');
 const twitter = require('../../src/services/twitter');
-const fakeImages = require('../data/s3-response-list-objects-v2.json').Contents
-const uploadImageAPIResponse = require('../data/twitter-response-upload-image.json')
+const fakeImages = require('../data/s3-response-list-objects-v2.json').Contents;
+const uploadImageAPIResponse = require('../data/twitter-response-upload-image.json');
 
 jest.mock('s3');
 jest.mock('twitter');
@@ -13,14 +13,14 @@ afterEach(() => {
 });
 
 test('handler exists', () => {
-  expect(handler()).toBeDefined()
+  expect(handler()).toBeDefined();
 })
 
 describe('Empty staging folder reaction', () => {
-  test('Staging folder gets repopulated if it is empty', async() => {
+  test('Staging folder gets repopulated if it is empty', async () => {
     // setup mocks
     // mock empty staging folder
-    s3.listObjects = await jest.fn().mockResolvedValue([])
+    s3.listObjects = await jest.fn().mockResolvedValue([]);
 
     // test and assert
     expect.assertions(1)
@@ -29,17 +29,10 @@ describe('Empty staging folder reaction', () => {
   })
 })
 
-// TOTEST:
-// encodedImage is a buffer
-// twitter.uploadImage and twitter.createTweet are called if isTweetingEnabled is true
-// twitter.uploadImage is called with encodedImage
-// twitter.createTweet is called with object containing "media_id"
-// 
-
 describe('Main tweeting function', () => {
-  test('twitter.uploadImage and twitter.createTweet are called if isTweetingEnabled is true', async() => {
+  test('twitter.uploadImage and twitter.createTweet are called if isTweetingEnabled is true', async () => {
     // setup mocks so that images are detected in the staging folder
-    index.isTweetingEnabled = jest.fn().mockReturnValue(true); 
+    index.isTweetingEnabled = jest.fn().mockReturnValue(true);
     s3.getObject = await jest.fn().mockResolvedValue('1');
     s3.listObjects = await jest.fn().mockResolvedValue(fakeImages);
     twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse)
@@ -52,7 +45,7 @@ describe('Main tweeting function', () => {
     expect(twitter.uploadImage).toHaveBeenCalled();
     expect(twitter.uploadImage).toHaveBeenCalledWith(expect.stringContaining(''));
     expect(twitter.createTweet).toHaveBeenCalled();
-    expect(twitter.createTweet).toHaveBeenCalledWith(expect.objectContaining({media_id: 1533168952922108000}));
+    expect(twitter.createTweet).toHaveBeenCalledWith(expect.objectContaining({ media_id: 1533168952922108000 }));
   })
 })
 
@@ -60,18 +53,17 @@ describe('Error catch of tweeting function', () => {
   test('Error from twitter calls handled', async () => {
     // mock twitter API error
     twitter.createTweet = jest.fn().mockRejectedValue(new Error('Twitter API is borked'));
-    // twitter.createTweet = jest.fn().mockRejectedValue(new Error({response: {data: 'Twitter API is borked'}}));
-    
+
     // setup mocks so that images are detected in the staging folder
-    index.isTweetingEnabled = jest.fn().mockReturnValue(true); 
+    index.isTweetingEnabled = jest.fn().mockReturnValue(true);
     s3.getObject = await jest.fn().mockResolvedValue('1');
     s3.listObjects = await jest.fn().mockResolvedValue(fakeImages);
-    twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse)
-    console.error = jest.fn()
+    twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse);
+    console.error = jest.fn();
 
     // test and assert
     expect.assertions(2);
-    await expect(handler()).rejects.toThrow()
-    expect(console.error).toHaveBeenCalledWith('Twitter error details:', {})
+    await expect(handler()).rejects.toThrow();
+    expect(console.error).toHaveBeenCalledWith('Twitter error details:', {});
   })
 })

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,4 +1,4 @@
-// const { handler, isTweetingEnabled } = require('../../src/index-lambda-cat-bot');
+const { handler} = require('../../src/index-lambda-cat-bot');
 const index = require('../../src/index-lambda-cat-bot');
 const s3 = require('../../src/services/s3');
 const twitter = require('../../src/services/twitter');
@@ -7,7 +7,6 @@ const uploadImageAPIResponse = require('../data/twitter-response-upload-image.js
 
 jest.mock('s3');
 jest.mock('twitter');
-jest.mock('index');
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -20,30 +19,18 @@ test('this is a placeholder test', () => {
 
 
 test('handler exists', () => {
-  expect(index.handler()).toBeDefined()
+  expect(handler()).toBeDefined()
 })
 
 describe('Empty staging folder reaction', () => {
   test('Staging folder gets repopulated if it is empty', async() => {
     // setup mocks
-    // mock listObjects so that it returns an empty array
-
-    // const spy = await jest.spyOn(s3, 'listObjects');
-    // spy.mockReturnValue([]);
-
+    // mock empty staging folder
     s3.listObjects = await jest.fn().mockResolvedValue([])
-    // s3.listObjects.mockResolvedValue([])
 
-    // test
-    // call handler
-    // const test = async() => await handler()
+    // test and assert
+    await expect(handler()).rejects.toThrow('Successfully repopulated');
 
-    // assert 
-    // expect a error message will be returned
-    // error msg: `Successfully repopulated ${STAGING_FOLDER} folder with ${TWEETED_FOLDER} contents. Proceed to rerun Lambda.`
-    await expect(index.handler()).rejects.toThrow('Successfully repopulated');
-
-    // spy.mockRestore();
   })
 })
 
@@ -56,16 +43,17 @@ describe('Empty staging folder reaction', () => {
 
 describe('Main tweeting function', () => {
   test('twitter.uploadImage and twitter.createTweet are called if isTweetingEnabled is true', async() => {
-    // setup mocks
+    // setup mocks so that images are detected in the staging folder
     index.isTweetingEnabled = jest.fn().mockReturnValue(true); 
     s3.getObject = await jest.fn().mockResolvedValue('1');
     s3.listObjects = await jest.fn().mockResolvedValue(fakeImages);
     twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse)
 
     // test
-    const test = await index.handler();
+    const test = await handler();
 
     // assert
     expect(twitter.uploadImage).toHaveBeenCalled();
+    expect(twitter.createTweet).toHaveBeenCalled();
   })
 })

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,4 +1,3 @@
-const { handler } = require('../../src/index-lambda-cat-bot');
 const index = require('../../src/index-lambda-cat-bot');
 const s3 = require('../../src/services/s3');
 const twitter = require('../../src/services/twitter');
@@ -12,10 +11,6 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-test('handler exists', () => {
-  expect(handler()).toBeDefined();
-})
-
 describe('Empty staging folder reaction', () => {
   test('Staging folder gets repopulated if it is empty', async () => {
     // setup mocks
@@ -24,7 +19,7 @@ describe('Empty staging folder reaction', () => {
 
     // test and assert
     expect.assertions(1)
-    await expect(handler()).rejects.toThrow('Successfully repopulated');
+    await expect(index.handler).rejects.toThrow('Successfully repopulated');
 
   })
 })
@@ -38,7 +33,7 @@ describe('Main tweeting function', () => {
     twitter.uploadImage = await jest.fn().mockResolvedValue(uploadImageAPIResponse)
 
     // test
-    const test = await handler();
+    const test = await index.handler();
 
     // assert
     expect.assertions(4)
@@ -63,7 +58,7 @@ describe('Error catch of tweeting function', () => {
 
     // test and assert
     expect.assertions(2);
-    await expect(handler()).rejects.toThrow();
+    await expect(index.handler).rejects.toThrow();
     expect(console.error).toHaveBeenCalledWith('Twitter error details:', {});
   })
 })

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,4 +1,11 @@
+const { handler } = require('../../src/index-lambda-cat-bot');
+
 test('this is a placeholder test', () => {
   console.log('hello, i am running this test!!');
   expect(true).toBe(true);
 });
+
+
+test('handler exists', () => {
+  expect(handler()).toBeDefined()
+})

--- a/test/unit/index-lambda-cat-bot.test.js
+++ b/test/unit/index-lambda-cat-bot.test.js
@@ -1,4 +1,5 @@
 const { handler } = require('../../src/index-lambda-cat-bot');
+const s3 = require('../../src/services/s3');
 
 test('this is a placeholder test', () => {
   console.log('hello, i am running this test!!');
@@ -8,4 +9,27 @@ test('this is a placeholder test', () => {
 
 test('handler exists', () => {
   expect(handler()).toBeDefined()
+})
+
+describe('Empty staging folder reaction', () => {
+  test('Staging folder gets repopulated if it is empty', async() => {
+    // setup mocks
+    // mock listObjects so that it returns an empty array
+
+    // const spy = await jest.spyOn(s3, 'listObjects');
+    // spy.mockReturnValue([]);
+
+    s3.listObjects = await jest.fn().mockReturnValue([])
+
+    // test
+    // call handler
+    const test = async() => await handler()
+
+    // assert 
+    // expect a error message will be returned
+    // error msg: `Successfully repopulated ${STAGING_FOLDER} folder with ${TWEETED_FOLDER} contents. Proceed to rerun Lambda.`
+    expect(test).toThrow();
+
+    // spy.mockRestore();
+  })
 })


### PR DESCRIPTION
This branch has been updated to main as of today (9/11/22). This branch implements a test suite for `index-lambda-cat-bot.js`. It tests the following:

* Checks if the main tweeting functionality works by checking if `twitter.uploadImage()` and `twitter.createTweet()` are called if `isTweetingEnabled()` returns `true`
* Staging folder repopulation in the event of all the images already already having been posted
* If generic Twitter API errors are handled